### PR TITLE
integration of damspas into dams-vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
+damspas
 downloads
 *~

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ UCSD DAMS Vagrant Virtual Machine
 
 * [Vagrant](https://www.vagrantup.com/)
 * [VirtualBox](https://www.virtualbox.org/)
+* [Vagrant Triggers Plugin](https://github.com/emyl/vagrant-triggers)
+  * installation: `vagrant plugin install vagrant-triggers`
 
 ## Usage
 
@@ -19,25 +21,17 @@ You can load test records into DAMS Repository, installed in the Vagrant VM, usi
 ```
 curl -u dams:dams -d @your_damspas_path/damspas/spec/fixtures/damsObject.xml http://localhost:8080/dams/api/objects/bd22194583
 ```
-
-## DAMSPAS
-You will need a working copy of damspas on your host system. Since Vagrant forwards the tomcat port, you can simply setup DAMSPAS on your local laptop as you normally would.
-
-You **should not** install damspas within the vagrant vm. If you do, and then you `vagrant destroy` and `vagrant up` to update the VM, you will wipe out a damspas installation in the VM.
-
-1. Follow [DAMSPAS Setup
-   Instructions](https://github.com/ucsdlib/damspas/wiki/Setup)
-2. Execute entire test suite to ensure DAMSPAS is configured with the Vagrant
-   VM.
-
 ## Environment
 
-* Ubuntu 14.04 64-bit machine with: 
+* Ubuntu 14.04 64-bit machine with:
   * [Tomcat 7](http://tomcat.apache.org) at [http://localhost:8080](http://localhost:8080)
     * Manager username = "tomcat", password = "tomcat"
   * [DAMS Repository](https://github.com/ucsdlib/damsrepo) at [http://localhost:8080/dams](http://localhost:8080/dams)
     * Installed in Tomcat container
     * Data and configuration files in "/pub/dams"
+  * [Digital Collections](https://github.com/ucsdlib/damspas) at [http://localhost:3000](http://localhost:3000)
+    * Repository code will be available in the /dams-vagrant root on the host marchine. You can edit source using your editor of choice.
+    * On the guest/vm the code directory is available in `/vagrant/damspas`
   * [Solr 4.0.0](http://lucene.apache.org/solr/) at [http://localhost:8080/solr](http://localhost:8080/solr), for indexing & searching your content.
     * Installed in Tomcat container
     * Data and configuration files in "/var/lib/tomcat7/solr"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   config.vm.network :forwarded_port, guest: 8080, host: 8080 # Tomcat
+  config.vm.network :forwarded_port, guest: 3000, host: 3000 # DAMSPAS
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
+  end
+
+  # using vagrant-triggers plugin, remove downloads and damspas directories on destroy
+  config.trigger.after :destroy do
+    run "rm -rf damspas"
+    run "rm -rf downloads"
   end
 
   shared_dir = "/vagrant"
@@ -25,4 +32,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "./install_scripts/tomcat7.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/solr.sh", args: shared_dir
   config.vm.provision "shell", path: "./install_scripts/damsrepo.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/wowza.sh", args: shared_dir
+  config.vm.provision "shell", path: "./install_scripts/rbenv.sh", privileged: false
+  config.vm.provision "shell", path: "./install_scripts/ruby.sh", privileged: false
+  config.vm.provision "shell", path: "./install_scripts/damspas.sh", args: shared_dir, privileged: false
 end

--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -18,6 +18,8 @@ apt-get -y install openssh-server
 
 # Build tools
 apt-get -y install build-essential
+apt-get -y install libgmp3-dev #fixes https://github.com/flori/json/issues/253
+apt-get -y install libreadline-dev libyaml-dev libsqlite3-dev libqtwebkit-dev
 
 # Git vim
 apt-get -y install git vim
@@ -28,8 +30,12 @@ apt-get -y install wget curl
 # More helpful packages
 apt-get -y install htop tree zsh fish
 
+# NodeJS
+apt-get -y install nodejs
+
 # Postgresql
 apt-get -y install postgresql
+apt-get -y install libpq-dev
 
 # Image Magick
 apt-get -y install imagemagick

--- a/install_scripts/damspas.sh
+++ b/install_scripts/damspas.sh
@@ -1,6 +1,27 @@
 #!/bin/sh
-
+echo "Cloning DAMSPAS..."
+cd $1
 git clone https://github.com/ucsdlib/damspas.git
 cd damspas
+git checkout -f develop
 
-#XXX bundle install, db migrations, etc...
+echo "Installing DAMSPAS..."
+# copy config files
+cp config/database.yml.sample config/database.yml
+cp config/fedora.yml.sample config/fedora.yml
+cp config/solr.yml.sample config/solr.yml
+cp config/initializers/devise.rb.sample config/initializers/devise.rb
+cp config/initializers/secret_token.rb.sample config/initializers/secret_token.rb
+
+# install gems
+bundle install
+
+echo "Executing DAMSPAS test suite..."
+# setup test DB and  run test suite
+bundle exec rake db:migrate RAILS_ENV=test
+bundle exec rake spec
+
+# setup local db and start server
+bundle exec rake db:migrate
+echo "Starting DAMSPAS web server as background process..."
+unicorn -D -p 3000

--- a/install_scripts/rbenv.sh
+++ b/install_scripts/rbenv.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Installing rbenv..."
+
+# install rbenv and ruby-build
+git clone git://github.com/sstephenson/rbenv.git /home/vagrant/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> /home/vagrant/.profile
+echo 'eval "$(rbenv init -)"' >> /home/vagrant/.profile
+git clone git://github.com/sstephenson/ruby-build.git /home/vagrant/.rbenv/plugins/ruby-build

--- a/install_scripts/ruby.sh
+++ b/install_scripts/ruby.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# install required ruby versions
+echo "Installing ruby..."
+ruby_version="$(curl -sSL https://raw.githubusercontent.com/ucsdlib/damspas/develop/.ruby-version)"
+rbenv install "$ruby_version"
+rbenv global "$ruby_version"
+ruby -v
+gem install bundler --no-ri --no-rdoc
+rbenv rehash

--- a/install_scripts/wowza.sh
+++ b/install_scripts/wowza.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "Setting up Wowza key for DAMSPAS..."
+# setup wowza streaming key
+WOWZA_DIR=/pub/data2/dams
+sudo mkdir -p ${WOWZA_DIR}
+sudo touch ${WOWZA_DIR}/streaming.key
+sudo echo "1234123123123123" > ${WOWZA_DIR}/streaming.key
+sudo chown -R vagrant:vagrant $WOWZA_DIR


### PR DESCRIPTION
Changes:
- Include DAMSPAS, exposing it as a synced folder so developers can edit code in their host system. In the vm, this will be in `/vagrant/damspas` (see README)
- requires vagrant-triggers plugin to cleanup the synced folders: damspas, downloads (see README)
- DAMSPAS test suite will run automatically as part of `vagrant up`
- DAMSPAS app will be started using unicorn, in daemon mode, and forwarded on port 3000
- The version of Ruby installed will be the ruby.version specificed in damspas
- Ruby is installed from source, using rbenv
