### PR TITLE
Prefix unicorn with bundle exec

### DIFF
--- a/install_scripts/bootstrap.sh
+++ b/install_scripts/bootstrap.sh
@@ -27,9 +27,6 @@ apt-get -y install git vim
 # Wget and curl
 apt-get -y install wget curl
 
-# More helpful packages
-apt-get -y install htop tree zsh fish
-
 # NodeJS
 apt-get -y install nodejs
 

--- a/install_scripts/damspas.sh
+++ b/install_scripts/damspas.sh
@@ -18,4 +18,4 @@ bundle exec rake spec
 # setup local db and start server
 bundle exec rake db:migrate
 echo "Starting DAMSPAS web server as background process..."
-unicorn -D -p 3000
+bundle exec unicorn -D -p 3000


### PR DESCRIPTION
Because the shell script that is executing unicorn does not yet have the
rbenv shims on it's PATH, the script fails to execute unicorn. Prefixing
with bundle exec should fix is the issue, hopefully.

Also removing completely unnecessary packages. There are certainly more,
but these are the most obvious.

@ucsdlib/developers - Please try this out if you get a chance. This worked locally but due to the non-idempotent nature of these scripts I'm a bit skeptical, so some confirmation would be great.

Fixes: #10 #11 