### PR TITLE
Support dynamic damspas version/branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ UCSD DAMS Vagrant Virtual Machine that is provisioned via Ansible.
 3. `make all`
 4. `ansible-playbook main.yml`
 
+> If you want to run the tests against a different branch or tag than `develop` you can
+> specify that in the playbook command above, such as:
+>
+> `ansible-playbook main.yml --extra-vars "damspas_version=feature/my-widget"`
+> This will ensure the initially checked out branch of damspas is what you want.
+
 At this point the virtual machine will be up and running! You do **not** need to
 run `vagrant up`.
 

--- a/tasks/damspas.yml
+++ b/tasks/damspas.yml
@@ -3,7 +3,7 @@
   git:
     repo: https://github.com/ucsdlib/damspas.git
     dest: "{{ damspas_shared_dir }}/damspas"
-    version: 'develop'
+    version: "{{ damspas_version }}"
 
 - name: Bundle install
   bundler:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@ damspas_home_dir: '/home/vagrant'
 damspas_shared_dir: '/vagrant'
 damspas_solr_version: 4.10.3
 damspas_solr_home: /var/lib/tomcat7/solr
+damspas_version: 'develop'
 damspas_damsrepo_home: /pub/dams
 damspas_packages:
   - ant


### PR DESCRIPTION
Previously the  branch of damspas that was checked out by the playbook
was develop, and this was hard-coded. It would be nice to be able to
specify an alternative branch when doing testing. This commit adds support
for that and instructions in the README for how to do it

@ucsdlib/developers please review